### PR TITLE
FEAT : 마이페이지 API, 방 관련 API 구현

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,10 +3,14 @@ import Input from "./Input";
 import Button from "./Button";
 import { useAuth } from "../hooks/useAuth";
 import { InputErr } from "../types";
+import AlertModal from "./modal/AlertModal";
 
 const Login = () => {
   const { setEmail, setPassword, email, password, handleLogin } = useAuth();
   const [inputErr, setInputErr] = useState<InputErr | null>(null);
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const handleClose = () => setOpen(false);
 
   const isValidateValue = () => {
     const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
@@ -27,12 +31,16 @@ const Login = () => {
 
     if (isErr) return;
 
-    handleLogin();
+    handleLogin().catch(e => {
+      setMessage(e.response.data.message);
+      setOpen(true);
+    });
   };
 
   return (
     <>
       <div className="flex flex-[2] flex-col items-center justify-around w-full pl-5 pr-5">
+        <AlertModal open={open} handleClose={handleClose} message={message} />
         <div className="flex flex-col items-center">
           <div className="text-xl font-titleW">Login</div>
           <div className="text-sm">To access your account</div>

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -3,6 +3,7 @@ import { useLocation } from "react-router-dom";
 import rankImg from "../asset/img/ranking.png";
 import Input from "./Input";
 import { IoSearch } from "react-icons/io5";
+import { userStore } from "../store/userStore";
 
 interface MainContainer {
   children: React.ReactNode;
@@ -12,12 +13,13 @@ const MainContainer = ({ children }: MainContainer) => {
   const location = useLocation();
   const path = location.pathname;
   const [pageText, setPageText] = useState<string | null>(null);
+  const user = userStore(state => state.user);
 
   useEffect(() => {
     function printPageText() {
       switch (path) {
         case "/":
-          setPageText(`${"홍길동님"} 안녕하세요!`); //차후 유저 닉네임은 전역 상태 참조
+          setPageText(`${user.nickname} 안녕하세요!`); //차후 유저 닉네임은 전역 상태 참조
           break;
         case "/rank":
           setPageText("Ranking");
@@ -43,17 +45,17 @@ const MainContainer = ({ children }: MainContainer) => {
       min-w-[900px]
       max_950px:w-screen
       bg-blue-100
-      ">
+      "
+    >
       {pageText && (
         <div
           className={`flex justify-between items-end w-full h-[15%] gap-4 px-10 pb-5 font-titleW text-xl bg-blue-100 ${
             path === "/rank" && "text-rankText"
-          }`}>
+          }`}
+        >
           <div className="flex items-end">
             {pageText}
-            {path === "/rank" && (
-              <img src={rankImg} className="w-12 h-12"></img>
-            )}
+            {path === "/rank" && <img src={rankImg} className="w-12 h-12"></img>}
           </div>
           <div className="flex items-center gap-5">
             <Input type="normal" placeholder="방 이름을 입력해주세요." />
@@ -67,7 +69,8 @@ const MainContainer = ({ children }: MainContainer) => {
         className="h-[80%] bg-[#BFDBFE] overflow-y-auto mr-5 max_950px:ml-5 rounded-2xl max-h-full p-5 shadow-inner"
         style={{
           boxShadow: `inset 8px 8px 16px #97adc9, inset -8px -8px 16px #e7ffff`,
-        }}>
+        }}
+      >
         {children}
       </div>
     </div>

--- a/src/components/Rank/RankContainer.tsx
+++ b/src/components/Rank/RankContainer.tsx
@@ -7,27 +7,20 @@ interface Props {
   ranking: number;
 }
 
-const RankContainer = ({
-  profileUrl,
-  nickname,
-  totalScore,
-  ranking,
-}: Props) => {
+const RankContainer = ({ profileUrl, nickname, totalScore, ranking }: Props) => {
   return (
     //각각 1의 비율로 정렬
     <tr className="grid grid-cols-4 items-center justify-center bg-white border rounded-2xl">
       <td className="text-center p-2">{ranking}</td>
       <td className="flex justify-center p-2">
         <img
-          src={profileUrl}
+          src={`${import.meta.env.VITE_IMG_URL}${profileUrl}`}
           alt=""
           className="h-20 w-20 object-cover rounded-full"
         />
       </td>
       <td className="text-center p-2">{nickname}</td>
-      <td className="text-center p-2 font-titleW text-2xl underline">
-        {totalScore}
-      </td>
+      <td className="text-center p-2 font-titleW text-2xl underline">{totalScore}</td>
     </tr>
   );
 };

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import Button from "./Button";
 import { useNavigate } from "react-router-dom";
 import AlertModal from "./modal/AlertModal";
+import { Room as IRoom } from "../types";
 
 interface Props {
   roomId: string;
@@ -10,50 +11,39 @@ interface Props {
   roomName: string;
   currentUser: number;
   maxUser: number;
-  started: boolean;
+  roomStatus: "waiting" | "playing";
 }
 
-const Room = ({
-  roomId,
-  profileUrl,
-  roomMaster,
-  roomName,
-  currentUser,
-  maxUser,
-  started,
-}: Props) => {
+const Room = ({ roomId, masterImage, masterNickname, roomName, roomUsersCount, roomMaxCount, roomStatus }: IRoom) => {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
   const handleClose = () => setOpen(false);
 
   const handleInGame = () => {
-    if (started) {
+    if (roomStatus === "playing") {
       return setOpen(true);
     }
     navigate(`/ingame/${roomId}`);
   };
   return (
     <div className="flex w-full h-full rounded-xl border bg-white">
-      <AlertModal open={open} handleClose={handleClose} />
+      <AlertModal open={open} handleClose={handleClose} message="이미 게임이 시작된 방입니다" />
       <div className="w-3/4 h-full">
         <img
-          src={profileUrl}
+          src={`${import.meta.env.VITE_IMG_URL}${masterImage}`}
           alt="roomImg"
           className="w-full h-full object-cover rounded-xl"
         />
       </div>
       <div className="h-full w-full flex flex-col  justify-around">
         <div className="flex justify-end pr-3">
-          <div
-            className={`w-5 h-5 ${
-              started ? "bg-inGame" : "bg-waitingGame"
-            } rounded-full`}></div>
+          <div className={`w-5 h-5 ${roomStatus === "playing" ? "bg-inGame" : "bg-waitingGame"} rounded-full`}></div>
         </div>
         <div className="flex flex-col pl-3">
           <p className="font-titleW text-2xl">{roomName}</p>
           <div className="opacity-[0.5]">
-            <p>{roomMaster}</p>
-            {currentUser} / {maxUser}
+            <p>{masterNickname}</p>
+            {roomUsersCount} / {roomMaxCount}
           </div>
           <Button buttonStyle="ingame" onClick={handleInGame}>
             방 참가하기

--- a/src/components/api/rank.api.ts
+++ b/src/components/api/rank.api.ts
@@ -1,0 +1,7 @@
+import { RankUsers } from "../../types";
+import { httpClient } from "./http";
+
+export const fetchRank = async () => {
+  const res = await httpClient.get<RankUsers>("/rank");
+  return res.data;
+};

--- a/src/components/api/replace.api.ts
+++ b/src/components/api/replace.api.ts
@@ -1,0 +1,11 @@
+import { httpClient } from "./http";
+
+export const replacePassword = async (data: { password: string }) => {
+  const res = await httpClient.put("/mypage/passwordReset", data);
+  return res.data;
+};
+
+export const replaceNickName = async (data: { nickname: string }) => {
+  const res = await httpClient.put<{ nickname: string }>("/mypage/changeNickname", data);
+  return res.data;
+};

--- a/src/components/api/room.api.ts
+++ b/src/components/api/room.api.ts
@@ -1,0 +1,22 @@
+import { Room, Rooms } from "../../types";
+import { httpClient } from "./http";
+
+export const createRoom = async (data: { roomName: string }) => {
+  const res = await httpClient.post<Room>("/home/createRoom", data);
+  return res.data;
+};
+
+export const getRooms = async (currentPage?: number, limit?: number) => {
+  if (currentPage && limit) {
+    const res = await httpClient.get<Rooms>(`/home?page=${currentPage}&pageSize=${limit}`);
+    return res.data;
+  }
+
+  const res = await httpClient.get<Rooms>(`/home`);
+  return res.data;
+};
+
+export const joinRoom = async (data: { roomId: string }) => {
+  const res = await httpClient.post("/home/enterRoom", data);
+  return res.data;
+};

--- a/src/components/modal/AlertModal.tsx
+++ b/src/components/modal/AlertModal.tsx
@@ -4,9 +4,10 @@ import React from "react";
 interface Props {
   open: boolean;
   handleClose: () => void;
+  message: string;
 }
 
-const AlertModal = ({ open, handleClose }: Props) => {
+const AlertModal = ({ open, handleClose, message }: Props) => {
   const style = {
     position: "absolute" as "absolute",
     top: "50%",
@@ -30,7 +31,7 @@ const AlertModal = ({ open, handleClose }: Props) => {
     >
       <Box sx={style}>
         <Typography id="modal-modal-title" variant="h6" component="h2">
-          이미 게임이 시작된 방입니다.
+          {message}
         </Typography>
       </Box>
     </Modal>

--- a/src/components/modal/CreateRoomModal.tsx
+++ b/src/components/modal/CreateRoomModal.tsx
@@ -5,6 +5,9 @@ import React, { useState } from "react";
 import Input from "../Input";
 import Button from "../Button";
 import { Button as MButton } from "@mui/material";
+import { createRoom } from "../api/room.api";
+import { userStore } from "../../store/userStore";
+import { useNavigate } from "react-router-dom";
 
 const style = {
   position: "absolute",
@@ -26,7 +29,18 @@ const CreateRoomModal = () => {
   const [open, setOpen] = useState(false);
   const handleOpen = () => setOpen(true);
   const handleClose = () => setOpen(false);
-
+  const [roomName, setRoomName] = useState("");
+  const user = userStore(state => state.user);
+  const navigate = useNavigate();
+  console.log(user);
+  const handleCreateRoom = () => {
+    createRoom({ roomName: roomName })
+      .then(data => {
+        navigate(`/ingame/${data.roomId}`); //방생성 성공시 방으로 리다이렉트
+        console.log(data);
+      })
+      .catch(e => console.log(e));
+  };
   return (
     <>
       <Button buttonStyle="shadow" onClick={handleOpen}>
@@ -37,20 +51,17 @@ const CreateRoomModal = () => {
         open={open}
         onClose={handleClose}
         aria-labelledby="modal-modal-title"
-        aria-describedby="modal-modal-description">
+        aria-describedby="modal-modal-description"
+      >
         <Box sx={style}>
-          <Typography
-            sx={{ borderBottom: "2px solid" }}
-            id="modal-modal-title"
-            variant="h6"
-            component="h2">
+          <Typography sx={{ borderBottom: "2px solid" }} id="modal-modal-title" variant="h6" component="h2">
             방 만들기
           </Typography>
           <Typography id="modal-modal-title" variant="h6" component="h2">
             제목
-            <Input type="normal" />
+            <Input type="normal" onChange={e => setRoomName(e.target.value)} />
           </Typography>
-          <MButton onClick={() => {}}>방 생성</MButton>
+          <MButton onClick={handleCreateRoom}>방 생성</MButton>
         </Box>
       </Modal>
     </>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,24 +10,35 @@ export const useAuth = () => {
   const [nickname, setNickname] = useState<string>("");
   const setUser = userStore(state => state.setUser);
 
-  const handleLogin = () => {
-    login({ email, password })
+  const handleLogin = async () => {
+    return login({ email, password })
       .then(data => {
         localStorage.setItem("token", data.token);
-        setUser({ email: data.email, nickname: data.nickname, profileImage: data.profileImage, score: data.score });
+        setUser({
+          email: data.email,
+          nickname: data.nickname,
+          profileImage: `${import.meta.env.VITE_IMG_URL}${data.profileImage}`,
+          score: data.score,
+        });
         alert(`${data.nickname} 안녕하세요!`); //알럿창 수정 필요(디자인)
         navigate("/");
       })
-      .catch(e => console.log(e));
+      .catch(e => {
+        console.log(e);
+        throw e;
+      });
   };
 
-  const handleSignUp = () => {
-    signUp({ email, password, nickname })
+  const handleSignUp = async () => {
+    return signUp({ email, password, nickname })
       .then(() => {
         alert("회원가입 성공"); //알럿창 수정 필요(디자인)
         handleLogin(); //회원가입 성공시 바로 로그인후 홈으로 리다이렉트
       })
-      .catch(e => console.log(e));
+      .catch(e => {
+        console.log(e);
+        throw e;
+      });
   };
 
   return { handleLogin, handleSignUp, email, password, nickname, setEmail, setNickname, setPassword };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,72 +1,98 @@
+import { Navigate } from "react-router-dom";
 import Pagination from "../components/Home/Pagination";
 import Room from "../components/Room";
 import CreateRoomModal from "../components/modal/CreateRoomModal";
+import { getToken } from "../store/userStore";
+import { getRooms } from "../components/api/room.api";
+import { useEffect, useState } from "react";
+import { Room as IRoom } from "../types";
 
 //임시 데이터
-const roomsData = [
-  {
-    roomId: "1",
-    profileUrl: "https://picsum.photos/500/500",
-    roomMaster: "골목대장",
-    roomName: "방 제목",
-    currentUser: 3,
-    maxUser: 6,
-    started: false,
-  },
-  {
-    roomId: "2",
-    profileUrl: "https://picsum.photos/500/500",
-    roomMaster: "골목대장",
-    roomName: "방 제목",
-    currentUser: 3,
-    maxUser: 6,
-    started: false,
-  },
-  {
-    roomId: "3",
-    profileUrl: "https://picsum.photos/500/500",
-    roomMaster: "골목대장",
-    roomName: "방 제목",
-    currentUser: 3,
-    maxUser: 6,
-    started: true,
-  },
-  {
-    roomId: "4",
-    profileUrl: "https://picsum.photos/500/500",
-    roomMaster: "골목대장",
-    roomName: "방 제목",
-    currentUser: 3,
-    maxUser: 6,
-    started: true,
-  },
-];
+// const roomsData = [
+//   {
+//     roomId: "1",
+//     profileUrl: "https://picsum.photos/500/500",
+//     roomMaster: "골목대장",
+//     roomName: "방 제목",
+//     currentUser: 3,
+//     maxUser: 6,
+//     started: false,
+//   },
+//   {
+//     roomId: "2",
+//     profileUrl: "https://picsum.photos/500/500",
+//     roomMaster: "골목대장",
+//     roomName: "방 제목",
+//     currentUser: 3,
+//     maxUser: 6,
+//     started: false,
+//   },
+//   {
+//     roomId: "3",
+//     profileUrl: "https://picsum.photos/500/500",
+//     roomMaster: "골목대장",
+//     roomName: "방 제목",
+//     currentUser: 3,
+//     maxUser: 6,
+//     started: true,
+//   },
+//   {
+//     roomId: "4",
+//     profileUrl: "https://picsum.photos/500/500",
+//     roomMaster: "골목대장",
+//     roomName: "방 제목",
+//     currentUser: 3,
+//     maxUser: 6,
+//     started: true,
+//   },
+// ];
 
-const pagination = {
-  currentPage: 1,
-  totalPage: 5,
-};
+// const pagination = {
+//   currentPage: 1,
+//   totalPage: 5,
+// };
 
 const Home = () => {
+  const token = getToken();
+  const [rooms, setRooms] = useState<IRoom[]>([]);
+  const [pagination, setPagination] = useState({ currentPage: 1, totalPage: 1 });
+
+  if (!token) {
+    return <Navigate to={"/auth"} />;
+  }
+
+  useEffect(() => {
+    //페이지가 바뀔떄마다 방 데이터 호출
+    //리액트 쿼리로 업그레이드 필요
+    getRooms().then(data => {
+      setPagination({ currentPage: data.currentPage, totalPage: data.totalPages });
+      setRooms(data.roomData);
+    });
+  }, [pagination.currentPage]);
+
   return (
     <div className="w-full h-full">
       <div className="h-[10%] flex mb-5 relative">
         <CreateRoomModal />
         <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
-          <Pagination pagination={pagination} />
+          <Pagination pagination={pagination && pagination} />
         </div>
       </div>
+
       <div className="grid grid-cols-2 grid-rows-2 overflow-auto h-[85%] gap-4">
-        {roomsData.map((room) => (
+        {rooms.length === 0 && (
+          <div className=" w-f h-full flex justify-end items-end font-titleW">방을 만들어 주세요!</div>
+        )}
+        {rooms.map(room => (
           <Room
             key={room.roomId}
-            profileUrl={room.profileUrl}
+            masterImage={room.masterImage}
             roomId={room.roomId}
-            roomMaster={room.roomMaster}
+            masterNickname={room.masterNickname}
             roomName={room.roomName}
-            currentUser={room.currentUser}
-            maxUser={room.maxUser}
-            started={room.started}
+            roomUsersCount={room.roomUsersCount}
+            roomMaxCount={room.roomMaxCount}
+            roomStatus={room.roomStatus}
           />
         ))}
       </div>

--- a/src/pages/InGame.tsx
+++ b/src/pages/InGame.tsx
@@ -1,7 +1,34 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { joinRoom } from "../components/api/room.api";
+import AlertModal from "../components/modal/AlertModal";
 
 const InGame = () => {
-  return <div>InGame</div>;
+  const { roomId } = useParams();
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+  const [message, setMessage] = useState("");
+  const handleClose = () => {
+    setOpen(true);
+    navigate("/");
+  };
+
+  useEffect(() => {
+    //방 입장시 한번만 API호출
+    joinRoom({ roomId: roomId! })
+      .then(data => console.log(data))
+      .catch(e => {
+        setMessage(e.response.data.message); //에러시 에러 메세지 출력
+        setOpen(true);
+      });
+  }, []);
+
+  return (
+    <div>
+      <AlertModal open={open} handleClose={handleClose} message={message} />
+      InGame
+    </div>
+  );
 };
 
 export default InGame;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -3,6 +3,9 @@ import Input from "../components/Input";
 import Button from "../components/Button";
 // import mascot from "../asset/img/mascot.png";
 import ImageModal from "../components/modal/ImageModal";
+import { replaceNickName, replacePassword } from "../components/api/replace.api";
+import { userStore } from "../store/userStore";
+import AlertModal from "../components/modal/AlertModal";
 
 const userData = [
   {
@@ -17,45 +20,58 @@ const userData = [
 const DEFAULT_PASSWORD = "****";
 
 const MyPage = () => {
+  const { user, setUser } = userStore();
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const [isNickDisabled, setNickDisabled] = useState(true);
   const [isPasswordDisabled, setPasswordDisabled] = useState(true);
-  const [currentNick, setCurrentNick] = useState(userData[0].nickname); //전역 상태 유저 닉넴
-  const [currentPwd, setCurrentPwd] = useState(DEFAULT_PASSWORD); //비밀번호 변경 상태
+  const [newNick, setNewNick] = useState(user.nickname!); //전역 상태 유저 닉넴
+  const [newPwd, setNewPwd] = useState(DEFAULT_PASSWORD); //비밀번호 변경 상태
+  const [open, setOpen] = useState(false);
+  const handleClose = () => setOpen(false);
+  const [AlretMessage, setAlretMessageMessage] = useState("");
   const nickNameRef = useRef<HTMLDivElement>(null);
   const passwordRef = useRef<HTMLDivElement>(null);
 
   const handleNickInputOpen = () => setNickDisabled(false);
-  const handlePasswordInputOpen = () => setPasswordDisabled(false);
+  const handlePasswordInputOpen = () => {
+    setPasswordDisabled(false);
+    setNewPwd("");
+  };
 
   const handleOutsideNickName = (e: MouseEvent) => {
-    if (
-      nickNameRef.current &&
-      !nickNameRef.current.contains(e.target as Node)
-    ) {
-      setCurrentNick(userData[0].nickname);
+    if (nickNameRef.current && !nickNameRef.current.contains(e.target as Node)) {
+      setNewNick(user.nickname!);
       setNickDisabled(true);
     }
   };
 
   const handleOutsidePassword = (e: MouseEvent) => {
-    if (
-      passwordRef.current &&
-      !passwordRef.current.contains(e.target as Node)
-    ) {
-      setCurrentPwd(DEFAULT_PASSWORD);
+    if (passwordRef.current && !passwordRef.current.contains(e.target as Node)) {
+      setNewPwd(DEFAULT_PASSWORD);
       setPasswordDisabled(true);
     }
   };
 
   const handleChageNickname = () => {
-    //API 호출...
-    alert(currentNick); //기능 확인 알럿
+    replaceNickName({ nickname: newNick })
+      .then(data => {
+        setUser({ ...user, nickname: data.nickname });
+        setAlretMessageMessage("닉네임 변경 완료");
+        setOpen(true);
+      })
+      .catch(e => {
+        setAlretMessageMessage(e.response.data.message);
+        setOpen(true);
+      });
   };
 
   const handleChagePassword = () => {
-    //API 호출...
-    alert(currentPwd); //기능 확인 알럿
+    replacePassword({ password: newPwd })
+      .then(data => {
+        setAlretMessageMessage("비밀번호 변경 완료");
+        setOpen(true);
+      })
+      .catch(e => console.log(e));
   };
 
   useEffect(() => {
@@ -66,26 +82,22 @@ const MyPage = () => {
       document.removeEventListener("mousedown", handleOutsideNickName);
       document.removeEventListener("mousedown", handleOutsidePassword);
     };
-  }, []);
+  }, [user]);
 
   return (
     <div className="grid grid-cols-2 max_950px:flex max_950px:flex-col max_950px:pt-20 h-full">
       {/* 아바타 , score */}
+      <AlertModal open={open} handleClose={handleClose} message={AlretMessage} />
       <div className="flex flex-col justify-center items-center">
         <div className="w-72 h-72">
           <div
             style={{
               boxShadow: "5px 5px 10px #99afcb, -5px -5px 10px #e5ffff",
             }}
-            className="bg-[#BFDBFE] rounded-2xl w-full h-full flex flex-col items-center justify-center">
-            <img
-              src={userData[0].profileUrl}
-              alt="user"
-              className="w-[80%] h-[80%] m-auto rounded-full"
-            />
-            <button
-              className="text-blue-500"
-              onClick={() => setModalOpen(true)}>
+            className="bg-[#BFDBFE] rounded-2xl w-full h-full flex flex-col items-center justify-center"
+          >
+            <img src={user.profileImage!} alt="user" className="w-[80%] h-[80%] m-auto rounded-full" />
+            <button className="text-blue-500" onClick={() => setModalOpen(true)}>
               replace
             </button>
             <ImageModal open={modalOpen} onClose={() => setModalOpen(false)} />
@@ -94,9 +106,7 @@ const MyPage = () => {
 
         <div className="p-5 rounded-3xl flex justify-center items-center flex-col max_950px:my-5">
           <h2 className="text-3xl">Total Score</h2>
-          <p className="text-5xl font-titleW p-3 underline">
-            {userData[0].totalScore}
-          </p>
+          <p className="text-5xl font-titleW p-3 underline">{user.score}</p>
         </div>
       </div>
       {/* 이메일, 비밀번호, 닉네임 */}
@@ -104,12 +114,7 @@ const MyPage = () => {
         <div className=" max_950px:flex max_950px:justify-between gap-5">
           <h2 className="text-lg">NickName</h2>
           <div className="flex" ref={nickNameRef}>
-            <Input
-              type="shadow"
-              value={currentNick}
-              disabled={isNickDisabled}
-              onChange={(e) => setCurrentNick(e.target.value)}
-            />
+            <Input type="shadow" value={newNick} disabled={isNickDisabled} onChange={e => setNewNick(e.target.value)} />
             {isNickDisabled ? (
               <Button buttonStyle="submit" onClick={handleNickInputOpen}>
                 수정하기
@@ -123,16 +128,16 @@ const MyPage = () => {
         </div>
         <div className="max_950px:flex max_950px:justify-between gap-5">
           <h2 className="text-lg">Email</h2>
-          <Input type="shadow" disabled value={userData[0].email} />
+          <Input type="shadow" disabled value={user.email!} />
         </div>
         <div className="max_950px:flex max_950px:justify-between gap-5 max_950px:pb-20">
           <h2 className="text-lg">PassWord</h2>
           <div className="flex" ref={passwordRef}>
             <Input
               type="shadow"
-              value={currentPwd}
+              value={newPwd}
               disabled={isPasswordDisabled}
-              onChange={(e) => setCurrentPwd(e.target.value)}
+              onChange={e => setNewPwd(e.target.value)}
             />
             {isPasswordDisabled ? (
               <Button buttonStyle="submit" onClick={handlePasswordInputOpen}>

--- a/src/pages/Rank.tsx
+++ b/src/pages/Rank.tsx
@@ -1,5 +1,9 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import RankContainer from "../components/Rank/RankContainer";
+import { getToken } from "../store/userStore";
+import { Navigate } from "react-router-dom";
+import { fetchRank } from "../components/api/rank.api";
+import { RankUsers } from "../types";
 
 //임시 데이터
 const rankData = [
@@ -41,6 +45,20 @@ const rankData = [
 ];
 
 const Rank = () => {
+  const token = getToken();
+
+  if (!token) {
+    return <Navigate to={"/auth"} />;
+  }
+
+  const [rankData, setRankData] = useState<RankUsers>([]);
+
+  useEffect(() => {
+    fetchRank()
+      .then(data => setRankData(data))
+      .catch(e => console.log(e));
+  }, []);
+
   return (
     <div className="overflow-auto max-h-full">
       <table className="w-full">
@@ -51,12 +69,15 @@ const Rank = () => {
           <th className="text-center">총점수</th>
         </thead>
         <tbody className="flex flex-col gap-2">
+          {rankData.length === 0 && (
+            <div className="w-full text-center mt-20 font-titleW">랭킹에 이름을 올려보세요!</div>
+          )}
           {rankData.map((user, i) => (
             <RankContainer
               key={i}
-              profileUrl={user.profileUrl}
+              profileUrl={user.profileImage}
               nickname={user.nickname}
-              totalScore={user.totalScore}
+              totalScore={user.score}
               ranking={i + 1}
             />
           ))}

--- a/src/store/userStore.ts
+++ b/src/store/userStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { User } from "../types";
+import { persist } from "zustand/middleware";
 
 interface Store {
   //스토어 타입들
@@ -15,7 +16,25 @@ export const removeToken = () => {
   localStorage.removeItem("token");
 };
 
-export const userStore = create<Store>(set => ({
-  user: { email: null, nickname: null, profileImage: null, score: null },
-  setUser: (user: User) => set({ user }),
-}));
+export const userStore = create(
+  persist<Store>(
+    set => ({
+      user: {
+        email: null,
+        nickname: null,
+        profileImage: null,
+        score: null,
+      },
+      setUser: (userInfo: User) =>
+        set({
+          user: {
+            email: userInfo.email,
+            nickname: userInfo.nickname,
+            profileImage: userInfo.profileImage,
+            score: userInfo.score,
+          },
+        }),
+    }),
+    { name: "userInfo" }
+  )
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,3 +23,25 @@ export interface InputErr {
   notValidType: "email" | "password" | "nickname";
   message: string;
 }
+
+export interface Room {
+  masterImage: string;
+  masterNickname: string;
+  roomId: string;
+  roomMaxCount: number;
+  roomName: string;
+  roomUsersCount: number;
+  roomStatus: "waiting" | "playing";
+}
+
+export interface Rooms {
+  currentPage: number;
+  roomData: Room[];
+  totalPages: number;
+}
+
+export type RankUsers = {
+  nickname: string;
+  profileImage: string;
+  score: number;
+}[];


### PR DESCRIPTION
### Types of changes

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 테스트케이스
- [ ] 컨벤션 수정
- [ ] 문서
- [ ] CI/CD
- [ ] 리팩토링

## issue

<!-- 수정하려는 현재 동작을 설명하거나 관련 문제에 대한 링크를 제공하십시오. -->

> 

### Summary

- 마이 페이지 API, 방 관련 API 구현

### Changes

- 마이 페이지 비밀번호 수정하기 클릭시 '****' 사라짐 구현
- 새로 고침시 유저 전역 상태 초기화 안되게 로컬스토리지에 저장
- 마이 페이지 정보 수정 API 구현
- 방 생성 API, 방 참가 API 구현
- 모든 API 요청에 에러시 에러 메세지 AlertModal 컴포넌트로 간단하게 에러 메세지 출력
- 랭킹 API 구현
- 홈, 랭킹 페이지 로그인 상태가 아니면 로그인 페이지로 리다이렉트

## 해당 PR이 다른 영역에 영향을 미치나요?

- [x] Yes
- [ ] No

### 특이사항 (Optional)

- 임시 데이터를 모두 주석 처리
- 방 생성 완료시 생성된 방으로 바로 리다이렉트 시킴 하지만 방 생성 API 호출시 db에 참여한 유저로 저장됨 그래서 
  리다이렉트시 이미 참여한 사용자 라는 에러 발생함
- VITE_IMG_URL 환경변수 추가(서버 주소 + 이미지 경로)
### Screenshots (Optional)
